### PR TITLE
Fix API login URL construction and secure store cipher check

### DIFF
--- a/pilates-booking/mobile/src/api/client.ts
+++ b/pilates-booking/mobile/src/api/client.ts
@@ -6,6 +6,10 @@ class ApiClient {
   private instance: AxiosInstance;
   private currentBaseURL: string = API_BASE_URL;
 
+  private buildUrl(url: string): string {
+    return url.startsWith('/') ? url : `/${url}`;
+  }
+
   constructor() {
     this.instance = axios.create({
       baseURL: this.currentBaseURL,
@@ -65,7 +69,8 @@ class ApiClient {
         }
         
         // Debug logging
-        console.log(`API Request: ${config.method?.toUpperCase()} ${config.baseURL}${config.url}`);
+        const fullUrl = new URL(config.url ?? '', config.baseURL).toString();
+        console.log(`API Request: ${config.method?.toUpperCase()} ${fullUrl}`);
         
         return config;
       },
@@ -138,23 +143,23 @@ class ApiClient {
   }
 
   async get<T = any>(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
-    return this.instance.get(url, config);
+    return this.instance.get(this.buildUrl(url), config);
   }
 
   async post<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
-    return this.instance.post(url, data, config);
+    return this.instance.post(this.buildUrl(url), data, config);
   }
 
   async put<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
-    return this.instance.put(url, data, config);
+    return this.instance.put(this.buildUrl(url), data, config);
   }
 
   async patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
-    return this.instance.patch(url, data, config);
+    return this.instance.patch(this.buildUrl(url), data, config);
   }
 
   async delete<T = any>(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
-    return this.instance.delete(url, config);
+    return this.instance.delete(this.buildUrl(url), config);
   }
 }
 

--- a/pilates-booking/mobile/src/utils/secureStorage.ts
+++ b/pilates-booking/mobile/src/utils/secureStorage.ts
@@ -22,7 +22,7 @@ export class SecureStorage {
       // Use keychain on iOS and encrypted shared preferences on Android
       if (Platform.OS === 'ios') {
         options.keychainService = 'PilatesBookingKeychain';
-      } else {
+      } else if (SecureStore.ENCRYPTION_CIPHER?.AES_GCM) {
         options.encryptionCipher = SecureStore.ENCRYPTION_CIPHER.AES_GCM;
       }
 


### PR DESCRIPTION
## Summary
- normalize request paths and improve API request logging
- guard SecureStore cipher usage when AES_GCM is unavailable

## Testing
- `npm test` (fails: No tests found)

------
https://chatgpt.com/codex/tasks/task_e_68a64e0548948329b95ab295c3693d38